### PR TITLE
Catch IllegalArgumentException on UUID create

### DIFF
--- a/src/main/java/io/nuvalence/websocketauth/authentication/WebSocketHandshakeAuthInterceptor.java
+++ b/src/main/java/io/nuvalence/websocketauth/authentication/WebSocketHandshakeAuthInterceptor.java
@@ -44,7 +44,7 @@ public class WebSocketHandshakeAuthInterceptor extends HttpSessionHandshakeInter
         try {
             return UUID.fromString(UriComponentsBuilder.fromHttpRequest(request).build()
                     .getQueryParams().get("authentication").get(0));
-        } catch (NullPointerException e) {
+        } catch (IllegalArgumentException | NullPointerException e) {
             return null;
         }
     }


### PR DESCRIPTION
Currently the code only handles the case when the supplied token is empty but it does not handle the case where the supplied token is an invalid UUID (for ex: `abcxyz`).

This PR handles when an invalid UUID is supplied as token value.